### PR TITLE
Add workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,25 @@
+name: Deploy frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build frontend
+        run: |
+          mkdir -p dist
+          cp -r frontend/* dist
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build frontend and deploy to gh-pages

## Testing
- `pytest` *(fails: UnboundLocalError: cannot access local variable 'response')*

------
https://chatgpt.com/codex/tasks/task_e_689636c802f8832795f1fce6c89f2810