### PR TITLE
Add workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,25 @@
+name: Deploy frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build frontend
+        run: |
+          mkdir -p dist
+          cp -r frontend/* dist
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -3,25 +3,33 @@ const chatLog = document.getElementById('chat-log');
 async function sendQuery() {
   const query = document.getElementById('query').value;
   if (!query) return;
-  const res = await fetch('/chat', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query })
-  });
-  const data = await res.json();
-  chatLog.textContent = data.answer || data.detail || 'Error';
+  try {
+    const res = await fetch('/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query })
+    });
+    const data = await res.json();
+    chatLog.textContent = data.answer || data.detail || 'Error';
+  } catch (err) {
+    chatLog.textContent = 'Request failed';
+  }
 }
 
 async function ingestUrl() {
   const url = document.getElementById('url').value;
   if (!url) return;
-  const res = await fetch('/ingest', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ url })
-  });
-  const data = await res.json();
-  alert(data.status ? `Ingested. Total documents: ${data.documents}` : data.detail);
+  try {
+    const res = await fetch('/ingest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url })
+    });
+    const data = await res.json();
+    alert(data.status ? `Ingested. Total documents: ${data.documents}` : data.detail);
+  } catch (err) {
+    alert('Request failed');
+  }
 }
 
 document.getElementById('send').addEventListener('click', sendQuery);


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build frontend and deploy to gh-pages
- handle network errors in the frontend so users see feedback when requests fail

## Testing
- `pytest` *(fails: UnboundLocalError: cannot access local variable 'response')*

------
https://chatgpt.com/codex/tasks/task_e_689636c802f8832795f1fce6c89f2810